### PR TITLE
Fix typo (Worldedge to Wordledge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Worldledge
+## Wordledge
 
 An implementation of [Wordle](https://www.powerlanguage.co.uk/wordle/) to help
 you learn Next.js and Vercel.

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -10,7 +10,7 @@ function MyApp({ Component, pageProps }) {
         <meta name="twitter:site" content="@rauchg" />
         <meta
           name="twitter:title"
-          content="Worldedge: Wordle on Next.js at the Edge"
+          content="Wordledge: Wordle on Next.js at the Edge"
         />
         <meta
           property="og:description"


### PR DESCRIPTION
This PR changes the title from "Worldedge" (world-edge 🗺️) to "Wordledge" (Wordle edge) which matches the name of the repository. 

This project is really neat!